### PR TITLE
webthing/server.py: fix handling of root path

### DIFF
--- a/webthing/server.py
+++ b/webthing/server.py
@@ -246,7 +246,10 @@ class WebThingServer:
 
     def getThing(self, routeArgs):
         """Get the thing ID based on the route."""
-        thing_id = routeArgs['thing_id'] if 'thing_id' in routeArgs else None
+        if not routeArgs:
+            thing_id = None
+        else:
+            thing_id = routeArgs['thing_id'] if 'thing_id' in routeArgs else None
         return self.things.get_thing(thing_id)
 
     def getProperty(self, routeArgs):

--- a/webthing/server.py
+++ b/webthing/server.py
@@ -246,10 +246,11 @@ class WebThingServer:
 
     def getThing(self, routeArgs):
         """Get the thing ID based on the route."""
-        if not routeArgs:
+        if not routeArgs or 'thing_id' not in routeArgs:
             thing_id = None
         else:
-            thing_id = routeArgs['thing_id'] if 'thing_id' in routeArgs else None
+            thing_id = routeArgs['thing_id']
+
         return self.things.get_thing(thing_id)
 
     def getProperty(self, routeArgs):


### PR DESCRIPTION
MicroWebSrv calls the handler with `RouteArgs = None` if root of weblink is accessed (e.g. by issuing a GET request on http://myipadress/

fixes #24 